### PR TITLE
add support for RDMA traffic in flow profiles

### DIFF
--- a/do.py
+++ b/do.py
@@ -103,6 +103,7 @@ def init():
     run(
         [
             py() + " -m pip install openapiart==0.1.34",
+            py() + " -m pip install openapi_spec_validator==0.3.0",
             py() + " -m pip install pytest-cov",
         ]
     )

--- a/docs/onexdataflow_openapi.yaml
+++ b/docs/onexdataflow_openapi.yaml
@@ -234,43 +234,76 @@ components:
           type: string
         data_size:
           type: integer
-        l2_protocol_choice:
+        mtu:
+          type: integer
           description: |-
-            layer2 protocol selection
+            Maximum Transmission Unit
+          default: 1500
+        choice:
+          description: |-
+            RDMA traffic or traditional TCP/IP
           type: string
           enum:
-          - ethernet
-        ethernet:
-          $ref: '#/components/schemas/Dataflow.FlowProfile.Ethernet'
-        l4_protocol_choice:
+          - rdma
+          - tcpip
+        rdma:
+          $ref: '#/components/schemas/Dataflow.FlowProfile.RdmaStack'
+        tcpip:
+          $ref: '#/components/schemas/Dataflow.FlowProfile.TcpIpStack'
+    Dataflow.FlowProfile.RdmaStack:
+      type: object
+      properties:
+        choice:
+          type: string
+          enum:
+          - rocev2
+        rocev2:
+          $ref: '#/components/schemas/Dataflow.FlowProfile.RdmaStack.RoceV2'
+    Dataflow.FlowProfile.RdmaStack.RoceV2:
+      type: object
+      properties:
+        verb:
+          description: |-
+            read or write command
+          type: string
+          enum:
+          - write
+          - read
+          default: write
+        bidirectional:
+          description: |-
+            whether data is sent both ways
+          type: boolean
+          default: false
+        iterations:
+          type: integer
+          description: |-
+            how many times to send the message
+          default: 1
+    Dataflow.FlowProfile.TcpIpStack:
+      type: object
+      properties:
+        ip:
+          $ref: '#/components/schemas/Dataflow.FlowProfile.TcpIpStack.Ip'
+        choice:
           description: |-
             layer4 protocol selection
           type: string
           enum:
           - tcp
           - udp
-        ip:
-          $ref: '#/components/schemas/Dataflow.FlowProfile.Ip'
         tcp:
-          $ref: '#/components/schemas/Dataflow.FlowProfile.Tcp'
+          $ref: '#/components/schemas/Dataflow.FlowProfile.L4Protocol.Tcp'
         udp:
-          $ref: '#/components/schemas/Dataflow.FlowProfile.Udp'
-    Dataflow.FlowProfile.Ethernet:
-      type: object
-      properties:
-        mtu:
-          type: integer
-          description: |-
-            Maximum Transmission Unit
-          default: 1500
-    Dataflow.FlowProfile.Ip:
+          $ref: '#/components/schemas/Dataflow.FlowProfile.L4Protocol.Udp'
+    Dataflow.FlowProfile.TcpIpStack.Ip:
       type: object
       properties:
         dscp:
           type: integer
           description: |-
             differentiated services code point
-    Dataflow.FlowProfile.Tcp:
+    Dataflow.FlowProfile.L4Protocol.Tcp:
       type: object
       properties:
         congestion_algorithm:
@@ -360,7 +393,7 @@ components:
           type: integer
           default: 1
           minimum: 1
-    Dataflow.FlowProfile.Udp:
+    Dataflow.FlowProfile.L4Protocol.Udp:
       type: object
     Dataflow.WorkloadItem:
       type: object

--- a/docs/onexdataflowapi.proto
+++ b/docs/onexdataflowapi.proto
@@ -271,54 +271,103 @@ message DataflowFlowProfile {
     (fld_meta).description = "Description missing in models"
   ];
 
-  message L2ProtocolChoice {
-    enum Enum {
-      unspecified = 0;
-      ethernet = 1;
-    }
-  }
-  optional L2ProtocolChoice.Enum l2_protocol_choice = 3 [
-    (fld_meta).description = "layer2 protocol selection"
+  optional int32 mtu = 3 [
+    (fld_meta).default = "1500",
+    (fld_meta).description = "Maximum Transmission Unit"
   ];
 
-  optional DataflowFlowProfileEthernet ethernet = 4 [
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      rdma = 1;
+      tcpip = 2;
+    }
+  }
+  optional Choice.Enum choice = 4 [
+    (fld_meta).description = "RDMA traffic or traditional TCP/IP"
+  ];
+
+  optional DataflowFlowProfileRdmaStack rdma = 5 [
     (fld_meta).description = "Description missing in models"
   ];
 
-  message L4ProtocolChoice {
+  optional DataflowFlowProfileTcpIpStack tcpip = 6 [
+    (fld_meta).description = "Description missing in models"
+  ];
+}
+
+message DataflowFlowProfileRdmaStack {
+  option (msg_meta).description = "Description missing in models";
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      rocev2 = 1;
+    }
+  }
+  optional Choice.Enum choice = 1 [
+    (fld_meta).description = "Description missing in models"
+  ];
+
+  optional DataflowFlowProfileRdmaStackRoceV2 rocev2 = 2 [
+    (fld_meta).description = "Description missing in models"
+  ];
+}
+
+message DataflowFlowProfileRdmaStackRoceV2 {
+  option (msg_meta).description = "Description missing in models";
+
+  message Verb {
+    enum Enum {
+      unspecified = 0;
+      write = 1;
+      read = 2;
+    }
+  }
+  optional Verb.Enum verb = 1 [
+    (fld_meta).default = "Verb.Enum.write",
+    (fld_meta).description = "read or write command"
+  ];
+
+  optional bool bidirectional = 2 [
+    (fld_meta).default = "False",
+    (fld_meta).description = "whether data is sent both ways"
+  ];
+
+  optional int32 iterations = 3 [
+    (fld_meta).default = "1",
+    (fld_meta).description = "how many times to send the message"
+  ];
+}
+
+message DataflowFlowProfileTcpIpStack {
+  option (msg_meta).description = "Description missing in models";
+
+  optional DataflowFlowProfileTcpIpStackIp ip = 1 [
+    (fld_meta).description = "Description missing in models"
+  ];
+
+  message Choice {
     enum Enum {
       unspecified = 0;
       tcp = 1;
       udp = 2;
     }
   }
-  optional L4ProtocolChoice.Enum l4_protocol_choice = 5 [
+  optional Choice.Enum choice = 2 [
     (fld_meta).description = "layer4 protocol selection"
   ];
 
-  optional DataflowFlowProfileIp ip = 6 [
+  optional DataflowFlowProfileL4ProtocolTcp tcp = 3 [
     (fld_meta).description = "Description missing in models"
   ];
 
-  optional DataflowFlowProfileTcp tcp = 7 [
-    (fld_meta).description = "Description missing in models"
-  ];
-
-  optional DataflowFlowProfileUdp udp = 8 [
+  optional DataflowFlowProfileL4ProtocolUdp udp = 4 [
     (fld_meta).description = "Description missing in models"
   ];
 }
 
-message DataflowFlowProfileEthernet {
-  option (msg_meta).description = "Description missing in models";
-
-  optional int32 mtu = 1 [
-    (fld_meta).default = "1500",
-    (fld_meta).description = "Maximum Transmission Unit"
-  ];
-}
-
-message DataflowFlowProfileIp {
+message DataflowFlowProfileTcpIpStackIp {
   option (msg_meta).description = "Description missing in models";
 
   optional int32 dscp = 1 [
@@ -326,7 +375,7 @@ message DataflowFlowProfileIp {
   ];
 }
 
-message DataflowFlowProfileTcp {
+message DataflowFlowProfileL4ProtocolTcp {
   option (msg_meta).description = "Description missing in models";
 
   message CongestionAlgorithm {
@@ -435,7 +484,7 @@ message L4PortRangeRange {
   ];
 }
 
-message DataflowFlowProfileUdp {
+message DataflowFlowProfileL4ProtocolUdp {
   option (msg_meta).description = "Description missing in models";
 }
 

--- a/docs/onexdatamodel_openapi.yaml
+++ b/docs/onexdatamodel_openapi.yaml
@@ -551,43 +551,76 @@ components:
           type: string
         data_size:
           type: integer
-        l2_protocol_choice:
+        mtu:
+          type: integer
           description: |-
-            layer2 protocol selection
+            Maximum Transmission Unit
+          default: 1500
+        choice:
+          description: |-
+            RDMA traffic or traditional TCP/IP
           type: string
           enum:
-          - ethernet
-        ethernet:
-          $ref: '#/components/schemas/Dataflow.FlowProfile.Ethernet'
-        l4_protocol_choice:
+          - rdma
+          - tcpip
+        rdma:
+          $ref: '#/components/schemas/Dataflow.FlowProfile.RdmaStack'
+        tcpip:
+          $ref: '#/components/schemas/Dataflow.FlowProfile.TcpIpStack'
+    Dataflow.FlowProfile.RdmaStack:
+      type: object
+      properties:
+        choice:
+          type: string
+          enum:
+          - rocev2
+        rocev2:
+          $ref: '#/components/schemas/Dataflow.FlowProfile.RdmaStack.RoceV2'
+    Dataflow.FlowProfile.RdmaStack.RoceV2:
+      type: object
+      properties:
+        verb:
+          description: |-
+            read or write command
+          type: string
+          enum:
+          - write
+          - read
+          default: write
+        bidirectional:
+          description: |-
+            whether data is sent both ways
+          type: boolean
+          default: false
+        iterations:
+          type: integer
+          description: |-
+            how many times to send the message
+          default: 1
+    Dataflow.FlowProfile.TcpIpStack:
+      type: object
+      properties:
+        ip:
+          $ref: '#/components/schemas/Dataflow.FlowProfile.TcpIpStack.Ip'
+        choice:
           description: |-
             layer4 protocol selection
           type: string
           enum:
           - tcp
           - udp
-        ip:
-          $ref: '#/components/schemas/Dataflow.FlowProfile.Ip'
         tcp:
-          $ref: '#/components/schemas/Dataflow.FlowProfile.Tcp'
+          $ref: '#/components/schemas/Dataflow.FlowProfile.L4Protocol.Tcp'
         udp:
-          $ref: '#/components/schemas/Dataflow.FlowProfile.Udp'
-    Dataflow.FlowProfile.Ethernet:
-      type: object
-      properties:
-        mtu:
-          type: integer
-          description: |-
-            Maximum Transmission Unit
-          default: 1500
-    Dataflow.FlowProfile.Ip:
+          $ref: '#/components/schemas/Dataflow.FlowProfile.L4Protocol.Udp'
+    Dataflow.FlowProfile.TcpIpStack.Ip:
       type: object
       properties:
         dscp:
           type: integer
           description: |-
             differentiated services code point
-    Dataflow.FlowProfile.Tcp:
+    Dataflow.FlowProfile.L4Protocol.Tcp:
       type: object
       properties:
         congestion_algorithm:
@@ -677,7 +710,7 @@ components:
           type: integer
           default: 1
           minimum: 1
-    Dataflow.FlowProfile.Udp:
+    Dataflow.FlowProfile.L4Protocol.Udp:
       type: object
     Dataflow.WorkloadItem:
       type: object

--- a/docs/onexmodel.proto
+++ b/docs/onexmodel.proto
@@ -643,54 +643,103 @@ message DataflowFlowProfile {
     (fld_meta).description = "Description missing in models"
   ];
 
-  message L2ProtocolChoice {
-    enum Enum {
-      unspecified = 0;
-      ethernet = 1;
-    }
-  }
-  optional L2ProtocolChoice.Enum l2_protocol_choice = 3 [
-    (fld_meta).description = "layer2 protocol selection"
+  optional int32 mtu = 3 [
+    (fld_meta).default = "1500",
+    (fld_meta).description = "Maximum Transmission Unit"
   ];
 
-  optional DataflowFlowProfileEthernet ethernet = 4 [
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      rdma = 1;
+      tcpip = 2;
+    }
+  }
+  optional Choice.Enum choice = 4 [
+    (fld_meta).description = "RDMA traffic or traditional TCP/IP"
+  ];
+
+  optional DataflowFlowProfileRdmaStack rdma = 5 [
     (fld_meta).description = "Description missing in models"
   ];
 
-  message L4ProtocolChoice {
+  optional DataflowFlowProfileTcpIpStack tcpip = 6 [
+    (fld_meta).description = "Description missing in models"
+  ];
+}
+
+message DataflowFlowProfileRdmaStack {
+  option (msg_meta).description = "Description missing in models";
+
+  message Choice {
+    enum Enum {
+      unspecified = 0;
+      rocev2 = 1;
+    }
+  }
+  optional Choice.Enum choice = 1 [
+    (fld_meta).description = "Description missing in models"
+  ];
+
+  optional DataflowFlowProfileRdmaStackRoceV2 rocev2 = 2 [
+    (fld_meta).description = "Description missing in models"
+  ];
+}
+
+message DataflowFlowProfileRdmaStackRoceV2 {
+  option (msg_meta).description = "Description missing in models";
+
+  message Verb {
+    enum Enum {
+      unspecified = 0;
+      write = 1;
+      read = 2;
+    }
+  }
+  optional Verb.Enum verb = 1 [
+    (fld_meta).default = "Verb.Enum.write",
+    (fld_meta).description = "read or write command"
+  ];
+
+  optional bool bidirectional = 2 [
+    (fld_meta).default = "False",
+    (fld_meta).description = "whether data is sent both ways"
+  ];
+
+  optional int32 iterations = 3 [
+    (fld_meta).default = "1",
+    (fld_meta).description = "how many times to send the message"
+  ];
+}
+
+message DataflowFlowProfileTcpIpStack {
+  option (msg_meta).description = "Description missing in models";
+
+  optional DataflowFlowProfileTcpIpStackIp ip = 1 [
+    (fld_meta).description = "Description missing in models"
+  ];
+
+  message Choice {
     enum Enum {
       unspecified = 0;
       tcp = 1;
       udp = 2;
     }
   }
-  optional L4ProtocolChoice.Enum l4_protocol_choice = 5 [
+  optional Choice.Enum choice = 2 [
     (fld_meta).description = "layer4 protocol selection"
   ];
 
-  optional DataflowFlowProfileIp ip = 6 [
+  optional DataflowFlowProfileL4ProtocolTcp tcp = 3 [
     (fld_meta).description = "Description missing in models"
   ];
 
-  optional DataflowFlowProfileTcp tcp = 7 [
-    (fld_meta).description = "Description missing in models"
-  ];
-
-  optional DataflowFlowProfileUdp udp = 8 [
+  optional DataflowFlowProfileL4ProtocolUdp udp = 4 [
     (fld_meta).description = "Description missing in models"
   ];
 }
 
-message DataflowFlowProfileEthernet {
-  option (msg_meta).description = "Description missing in models";
-
-  optional int32 mtu = 1 [
-    (fld_meta).default = "1500",
-    (fld_meta).description = "Maximum Transmission Unit"
-  ];
-}
-
-message DataflowFlowProfileIp {
+message DataflowFlowProfileTcpIpStackIp {
   option (msg_meta).description = "Description missing in models";
 
   optional int32 dscp = 1 [
@@ -698,7 +747,7 @@ message DataflowFlowProfileIp {
   ];
 }
 
-message DataflowFlowProfileTcp {
+message DataflowFlowProfileL4ProtocolTcp {
   option (msg_meta).description = "Description missing in models";
 
   message CongestionAlgorithm {
@@ -807,7 +856,7 @@ message L4PortRangeRange {
   ];
 }
 
-message DataflowFlowProfileUdp {
+message DataflowFlowProfileL4ProtocolUdp {
   option (msg_meta).description = "Description missing in models";
 }
 

--- a/model/dataflow/dataflow.yaml
+++ b/model/dataflow/dataflow.yaml
@@ -28,40 +28,75 @@ components:
           type: string
         data_size:
           type: integer
-
-        l2_protocol_choice:
-          description: layer2 protocol selection
-          type: string
-          enum: [ethernet]
-        ethernet:
-          $ref: "#/components/schemas/Dataflow.FlowProfile.Ethernet"
-        l4_protocol_choice:
-          description: layer4 protocol selection
-          type: string
-          enum: [tcp, udp]
-        ip:
-          $ref: "#/components/schemas/Dataflow.FlowProfile.Ip"
-        tcp:
-          $ref: "#/components/schemas/Dataflow.FlowProfile.Tcp"
-        udp:
-          $ref: "#/components/schemas/Dataflow.FlowProfile.Udp"
-
-    Dataflow.FlowProfile.Ethernet:
-      type: object
-      properties:
         mtu:
           type: integer
           description: Maximum Transmission Unit
           default: 1500
 
-    Dataflow.FlowProfile.Ip:
+        choice:
+          description: |-
+            RDMA traffic or traditional TCP/IP
+          type: string
+          enum: [rdma, tcpip]
+        rdma: 
+          $ref: "#/components/schemas/Dataflow.FlowProfile.RdmaStack"
+        tcpip:
+          $ref: "#/components/schemas/Dataflow.FlowProfile.TcpIpStack"
+        
+        
+
+    Dataflow.FlowProfile.RdmaStack:
+      type: object
+      properties:
+        choice:
+          type: string
+          enum: [rocev2]
+        rocev2:
+          $ref: "#/components/schemas/Dataflow.FlowProfile.RdmaStack.RoceV2"
+    
+    Dataflow.FlowProfile.RdmaStack.RoceV2:
+      type: object
+      properties:
+        verb:
+          description: read or write command
+          type: string
+          enum: [write, read]
+          default: write
+        bidirectional:
+          description: whether data is sent both ways
+          type: boolean
+          default: false
+        iterations:
+          type: integer
+          description: how many times to send the message
+          default: 1
+        
+
+    Dataflow.FlowProfile.TcpIpStack:
+      type: object
+      properties:
+        ip:
+          $ref: "#/components/schemas/Dataflow.FlowProfile.TcpIpStack.Ip"
+        choice:
+          description: layer4 protocol selection
+          type: string
+          enum: [tcp, udp]
+        tcp:
+          $ref: "#/components/schemas/Dataflow.FlowProfile.L4Protocol.Tcp"
+        udp:
+          $ref: "#/components/schemas/Dataflow.FlowProfile.L4Protocol.Udp"
+
+
+        
+
+    Dataflow.FlowProfile.TcpIpStack.Ip:
       type: object
       properties:
         dscp:
           type: integer
           description: differentiated services code point
 
-    Dataflow.FlowProfile.Tcp:
+    Dataflow.FlowProfile.L4Protocol.Tcp:
       type: object
       properties:
         congestion_algorithm:
@@ -142,7 +177,7 @@ components:
           default: 1
           minimum: 1
 
-    Dataflow.FlowProfile.Udp:
+    Dataflow.FlowProfile.L4Protocol.Udp:
       type: object
 
     Dataflow.WorkloadItem:

--- a/pytests/dataflow/test_flow_profile.py
+++ b/pytests/dataflow/test_flow_profile.py
@@ -1,16 +1,14 @@
 from typing import NamedTuple
 from artifacts.onex_model.onex_model import onex_model
 
-def test_flow_profile_network_parameters():
+def test_flow_profile_network_tcpip_parameters():
     config = onex_model.api().config()
-    fp = config.dataflow.flow_profiles.add(name='Test F Profile', data_size=1)
-    eth = fp.ethernet
-    eth.mtu = 1000
+    fp = config.dataflow.flow_profiles.add(name='Test F Profile', data_size=1, mtu=1000)
 
-    ip = fp.ip
+    ip = fp.tcpip.ip
     ip.dscp = 123
 
-    tcp = fp.tcp
+    tcp = fp.tcpip.tcp
     tcp.mss = 1500
     tcp.initcwnd = 100
     tcp.receive_buf = 40000
@@ -24,5 +22,17 @@ def test_flow_profile_network_parameters():
 
     tcp.source_port.single_value.value = 2000
     tcp.destination_port.single_value.value = 3000
+
+    assert config.serialize()
+
+
+def test_flow_profile_network_roce_parameters():
+    config = onex_model.api().config()
+    fp = config.dataflow.flow_profiles.add(name='Test F Profile', data_size=1, mtu=1000)
+
+    roce = fp.rdma.rocev2
+    roce.verb = "read"
+    roce.bidirectional = True
+    roce.iterations = 100
 
     assert config.serialize()


### PR DESCRIPTION
updated the flow profiles to have support for RDMA roce protocols. L4 protocol choice moved under tcpip object